### PR TITLE
Add missing word

### DIFF
--- a/book/trees/priority-queues-with-binary-heaps.md
+++ b/book/trees/priority-queues-with-binary-heaps.md
@@ -67,7 +67,7 @@ using a single list. We do not need to use nodes and references or even lists of
 lists. Because the tree is complete, the left child of a parent (at position
 $$p$$) is the node that is found in position $$2p$$ in the list. Similarly, the
 right child of the parent is at position $$2p + 1$$ in the list. To find the
-parent of any node in the tree, we can simply integer division (like normal
+parent of any node in the tree, we can simply use integer division (like normal
 mathematical division except we discard the remained). Given that a node is at
 position $$n$$ in the list, the parent is at position $$n/2$$.
 


### PR DESCRIPTION
"To find the parent of any node in the tree, we can simply integer division (like normal mathematical division except we discard the remained)." -> "To find the parent of any node in the tree, we can simply use integer division (like normal mathematical division except we discard the remained)."