### PR TITLE
Make the two Stack implementations consistent

### DIFF
--- a/book/stacks/stack_right.py
+++ b/book/stacks/stack_right.py
@@ -1,4 +1,4 @@
-class Stack(object):
+class Stack:
 
     def __init__(self):
         self._items = []


### PR DESCRIPTION
In terms of whether they inherit from `object` (now they both don't).