### PR TITLE
No need for .keys() for dict contains checks

### DIFF
--- a/book/trees/parse_tree.py
+++ b/book/trees/parse_tree.py
@@ -23,7 +23,7 @@ def build_parse_tree(expression):
             node = node['left']
         elif token == RIGHT_PAREN:
             node = stack.pop()
-        elif token in OPERATORS.keys():
+        elif token in OPERATORS:
             node['val'] = token
             node['right'] = {}
             stack.append(node)


### PR DESCRIPTION
That also degrades performance because .keys() is returning a list