### PR TITLE
Updating link for timsort explanation

### DIFF
--- a/book/analysis/performance-of-python-types.md
+++ b/book/analysis/performance-of-python-types.md
@@ -56,7 +56,7 @@ Reversing a list is $$O(n)$$ since we must reposition each element.
 
 ### Sorting
 
-Finally (and least intuitively), [sorting in Python](http://svn.python.org/view/python/trunk/Objects/listsort.txt?revision=69846&view=markup) is $$O(n\log{n})$$ and [beyond the scope of this book](https://en.wikipedia.org/wiki/Timsort) to demonstrate.
+Finally (and least intuitively), [sorting in Python](https://github.com/python/cpython/blob/main/Objects/listsort.txt) is $$O(n\log{n})$$ and [beyond the scope of this book](https://en.wikipedia.org/wiki/Timsort) to demonstrate.
 
 For reference, we’ve summarized the performance characteristics of
 Python's list operations in the table below:


### PR DESCRIPTION
The [current link](http://svn.python.org/view/python/trunk/Objects/listsort.txt?revision=69846&view=markup) for the explanation for timsort leads to login page at svn.python.org
<img width="965" alt="Screenshot 2023-09-02 at 6 02 13 PM" src="https://github.com/Bradfield/algos/assets/15229351/f73dcdf4-c706-4a31-a163-c89934c4c7c2">

The same file is accessible on GitHub here:
https://github.com/python/cpython/blob/main/Objects/listsort.txt

This also helps reinforce that it is indeed the Python implementation that's being talked about.