### PR TITLE
Changing operator.div to operator.truediv for Python3 compliance

### DIFF
--- a/book/stacks/postfix_evaluation.py
+++ b/book/stacks/postfix_evaluation.py
@@ -2,7 +2,7 @@ import operator
 
 OPERATION = {
     '*': operator.mul,
-    '/': operator.div,
+    '/': operator.truediv,
     '-': operator.sub,
     '+': operator.add
 }


### PR DESCRIPTION
I'm not sure whether the intent of the book is to be Python3 compliant or not. However, I noticed in my IDE that `operator.div` was not available on Python 3.10.


On further digging, I found that Python 3 removed `operator.div` in favour of two implementations: `operator.floordiv` and `operator.truediv`. 

Given two integer values, `floordiv` returns an integer, while `truediv` returns a float.

My change replaces `div` with `truediv`, since that's what the output value `3.0` is indicating.

Reference: https://docs.python.org/3/library/operator.html#mapping-operators-to-functions