### PR TITLE
Making queue class declaration consistent with stack class declaration

### DIFF
--- a/book/queues/queue.py
+++ b/book/queues/queue.py
@@ -1,5 +1,5 @@
 
-class Queue(object):
+class Queue():
     def __init__(self):
         self._items = []
 

--- a/book/queues/queue.py
+++ b/book/queues/queue.py
@@ -1,5 +1,5 @@
 
-class Queue():
+class Queue:
     def __init__(self):
         self._items = []
 


### PR DESCRIPTION
Currently, the two stack implementations declare a class without any parameters, while the queue implementation declares a class with `object` as its parent class.

Links: 
https://github.com/Bradfield/algos/blob/master/book/stacks/stack_left.py
https://github.com/Bradfield/algos/blob/master/book/stacks/stack_right.py
https://github.com/Bradfield/algos/blob/master/book/queues/queue.py

Classes in Python 3 inherit from object by default.
See: https://wiki.python.org/moin/NewClassVsClassicClass