### PR TITLE
Moving deque implementation to its own file

### DIFF
--- a/book/deques/deque.py
+++ b/book/deques/deque.py
@@ -1,0 +1,21 @@
+class Deque:
+    def __init__(self):
+        self._items = []
+
+    def is_empty(self):
+        return self._items == []
+
+    def add_front(self, item):
+        self._items.append(item)
+
+    def add_rear(self, item):
+        self._items.insert(0,item)
+
+    def remove_front(self):
+        return self._items.pop()
+
+    def remove_rear(self):
+        return self._items.pop(0)
+
+    def size(self):
+        return len(self._items)

--- a/book/deques/deque.py
+++ b/book/deques/deque.py
@@ -9,7 +9,7 @@ class Deque:
         self._items.append(item)
 
     def add_rear(self, item):
-        self._items.insert(0,item)
+        self._items.insert(0, item)
 
     def remove_front(self):
         return self._items.pop()

--- a/book/deques/deque_test.py
+++ b/book/deques/deque_test.py
@@ -1,0 +1,30 @@
+import unittest
+
+from deque import Deque
+
+cases = (
+    (lambda d: d.is_empty(), [], True),
+    (lambda d: d.add_rear(4), [4], None),
+    (lambda d: d.add_rear('dog'), ['dog', 4], None),
+    (lambda d: d.add_front('cat'), ['dog', 4, 'cat'], None),
+    (lambda d: d.add_front(True), ['dog', 4, 'cat', True], None),
+    (lambda d: d.size(), ['dog', 4, 'cat', True], 4),
+    (lambda d: d.is_empty(), ['dog', 4, 'cat', True], False),
+    (lambda d: d.add_rear(8.4), [8.4, 'dog', 4, 'cat', True], None),
+    (lambda d: d.remove_rear(), ['dog', 4, 'cat', True], 8.4),
+    (lambda d: d.remove_front(), ['dog', 4, 'cat'], True)
+)
+
+
+class TestCorrectness(unittest.TestCase):
+
+    def test_operates_correctly(self):
+        deque = Deque()
+        for operate, expected_state, expected_return in cases:
+            actual_return = operate(deque)
+            self.assertEqual(actual_return, expected_return)
+            self.assertEqual(deque._items, expected_state)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/book/deques/implementation.md
+++ b/book/deques/implementation.md
@@ -7,29 +7,7 @@ position: 3
 
 In practice, the most straightforward way to utilize a deque in Python will be to import `deque` from the `collections` module. For illustration purposes however, below we present a possible implementation of a deque using a Python list as the underlying concrete data type.
 
-```python
-class Deque(object):
-    def __init__(self):
-        self._items = []
-
-    def is_empty(self):
-        return self._items == []
-
-    def add_front(self, item):
-        self._items.append(item)
-
-    def add_rear(self, item):
-        self._items.insert(0,item)
-
-    def remove_front(self):
-        return self._items.pop()
-
-    def remove_rear(self):
-        return self._items.pop(0)
-
-    def size(self):
-        return len(self._items)
-```
+<!-- literate deques/deque.py -->
 
 In `remove_front` we use the `pop` method to remove the last element from
 the list. However, in `remove_rear`, the `pop(0)` method must remove the

--- a/book/deques/introduction.md
+++ b/book/deques/introduction.md
@@ -55,4 +55,4 @@ Deque Operation | Deque Contents | Return Value
 `d.is_empty()` | `['dog', 4, 'cat', True]` |   `False`
 `d.add_rear(8.4)` |  `[8.4, 'dog', 4, 'cat',True]` |
 `d.remove_rear()` |  `['dog', 4, 'cat', True]` |   `8.4`
-`d.remove_front()` | `['dog', 4, 'cat'] | `True`
+`d.remove_front()` | `['dog', 4, 'cat']` | `True`


### PR DESCRIPTION
This moves the deque implementation to its own file. Also fixed a typo involving a missing backtick in the table demonstration deque operations.

Note: Removed `(object)` from class declaration along the lines of https://github.com/Bradfield/algos/pull/112