### PR TITLE
Changing representation of base case to help understand form of recursion

### DIFF
--- a/book/recursion/tower-of-hanoi.md
+++ b/book/recursion/tower-of-hanoi.md
@@ -69,10 +69,12 @@ in steps 1 and 3. Below we present a possible Python solution to the Tower of Ha
 
 ```python
 def move_tower(height, from_pole, to_pole, with_pole):
-    if height >= 1:
-        move_tower(height - 1, from_pole, with_pole, to_pole)
-        move_disk(from_pole, to_pole)
-        move_tower(height - 1, with_pole, to_pole, from_pole)
+    if height == 0:
+        return
+    
+    move_tower(height - 1, from_pole, with_pole, to_pole)
+    move_disk(from_pole, to_pole)
+    move_tower(height - 1, with_pole, to_pole, from_pole)
 ```
 
 Notice that the code above is almost identical


### PR DESCRIPTION
This is an opinionated suggestion, feel free to not merge.

I think the fact that `height == 0` is the base case for the function is implicit, and maps slightly separately to the way the text talks about the base case.

By making a return explicit when height == 0, it helps to visualise how the call stack is being used.